### PR TITLE
removed height property from imgs in recipe.css

### DIFF
--- a/css/recipe.css
+++ b/css/recipe.css
@@ -58,7 +58,6 @@ a:visited {
 .gif-container img {
     display: inline-block;
     border: 1px solid black;
-    height: 30vh;
     width: 60vw;
 }
 


### PR DESCRIPTION
This change should allow the images to stay in their proper aspect ratio depending while scaling with the width.